### PR TITLE
fix: handle JSONB columns in attachments controller

### DIFF
--- a/src/controllers/attachments_controller.ts
+++ b/src/controllers/attachments_controller.ts
@@ -38,7 +38,9 @@ export default class AttachmentsController {
       /*
       * 1. Get the Attachment(s)
       */
-      const result = JSON.parse(queryWithTableSelection[data.attribute])
+      const result = typeof queryWithTableSelection[data.attribute] === 'string'
+        ? JSON.parse(queryWithTableSelection[data.attribute])
+        : queryWithTableSelection[data.attribute]
       const attachments: Attachment[] = []
       let currentAttachment: Attachment | null = null
 


### PR DESCRIPTION
## Summary

- Fix `JSON.parse` error when using PostgreSQL JSONB columns in the attachments controller
- JSONB columns are automatically parsed by the database driver, causing `JSON.parse()` to throw an error
- Adds a type check consistent with the existing pattern in `attachment_manager.ts` and `decorators/attachment.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)